### PR TITLE
Fix paths on windows

### DIFF
--- a/cargo-n64/src/cli.rs
+++ b/cargo-n64/src/cli.rs
@@ -206,7 +206,7 @@ crate fn parse_build_args(args: Args) -> Result<BuildArgs, ArgParseError> {
 fn create_target() -> Result<String, ArgParseError> {
     // Sad, but this little helper function really simplifies the error handling
     fn path_to_string(path: &std::path::Path) -> String {
-        path.to_string_lossy().to_string()
+        path.to_string_lossy().to_string().replace("\\", "/")
     }
 
     use self::ArgParseError::*;


### PR DESCRIPTION
When running to_string_lossy we get paths with "\" on windows. They are not valid in json.