### PR TITLE
Enable syntax highlighting in error messages

### DIFF
--- a/cargo-n64/src/cargo.rs
+++ b/cargo-n64/src/cargo.rs
@@ -91,7 +91,7 @@ crate fn run(args: &cli::BuildArgs) -> Result<CargoArtifact, SubcommandError> {
 
     let output = Command::new(env::current_exe().map_err(SubcommandError::ExePath)?)
         .arg("xbuild")
-        .arg("--message-format=json")
+        .arg("--message-format=json-render-diagnostics")
         .arg(format!("--target={}", args.target))
         .args(build_args)
         .stderr(Stdio::inherit())
@@ -141,7 +141,6 @@ where
             serde_json::from_str(s).map_err(|e| SubcommandError::JsonError(e, s.into()))?;
 
         if let Some(message) = message.message {
-            // TODO: Add highlighting
             eprintln!("{}", message.rendered);
         }
     }


### PR DESCRIPTION
Highlighting in errors is just a one-liner. Thanks to lights0123 in #26

<img width="739" alt="Screen Shot 2020-05-20 at 10 49 00 PM" src="https://user-images.githubusercontent.com/456942/82527851-4fccc280-9aec-11ea-844d-301118b88b75.png">