### PR TITLE
Update rrt0 and remove the empty loop

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -254,9 +254,9 @@ dependencies = [
 
 [[package]]
 name = "rrt0"
-version = "0.2.0"
+version = "0.2.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1f8a2ccc9ed17f5d5ecd1b9709ea3456c4d080243c6d50fa7ae12be34425356c"
+checksum = "51757480f8de75e061a1fcfd0ccbba6b88c8fc8975240ff700c4b528430eeba9"
 dependencies = [
  "libm",
 ]
@@ -309,9 +309,9 @@ dependencies = [
 
 [[package]]
 name = "serde_json"
-version = "1.0.60"
+version = "1.0.61"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1500e84d27fe482ed1dc791a56eddc2f230046a040fa908c08bda1d9fb615779"
+checksum = "4fceb2595057b6891a4ee808f70054bd2d12f0e97f1cbb78689b59f676df325a"
 dependencies = [
  "itoa",
  "ryu",

--- a/examples/hello-ipl3font/src/main.rs
+++ b/examples/hello-ipl3font/src/main.rs
@@ -18,7 +18,4 @@ fn main() {
 
     ipl3font::draw_str_centered(WHITE, "Hello, world!");
     vi::swap_buffer();
-
-    #[allow(clippy::empty_loop)]
-    loop {}
 }

--- a/examples/n64lib/src/ipl3font.rs
+++ b/examples/n64lib/src/ipl3font.rs
@@ -1,7 +1,7 @@
 //! IPL3 font renderer.
 //!
 //! Draws strings using the font embedded in the official Nintendo IPL3 bootcode.
-//! See: https://github.com/PeterLemon/N64/blob/master/BOOTCODE/IPL3Font.asm
+//! See: <https://github.com/PeterLemon/N64/blob/master/BOOTCODE/IPL3Font.asm>
 
 use crate::vi;
 


### PR DESCRIPTION
- Allows the rrt0 start function to panic when main returns
- Fixes undefined behavior
- See: https://github.com/rust-lang/rust/issues/28728