### PR TITLE
Replace `byteorder` and `itertools` crates with features available in `std`

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -33,14 +33,12 @@ checksum = "08c48aae112d48ed9f069b33538ea9e3e90aa263cfa3d1c24309612b1f7472de"
 name = "cargo-n64"
 version = "0.1.2"
 dependencies = [
- "byteorder",
  "colored",
  "crc32fast",
  "error-iter",
  "fatfs",
  "goblin",
  "gumdrop",
- "itertools",
  "serde",
  "serde_json",
  "thiserror",
@@ -90,12 +88,6 @@ checksum = "81156fece84ab6a9f2afdb109ce3ae577e42b1228441eded99bd77f627953b1a"
 dependencies = [
  "cfg-if 1.0.0",
 ]
-
-[[package]]
-name = "either"
-version = "1.6.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e78d4f1cc4ae33bbfc157ed5d5a5ef3bc29227303d595861deb238fcec4e9457"
 
 [[package]]
 name = "error-iter"
@@ -161,15 +153,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "5aca5565f760fb5b220e499d72710ed156fdb74e631659e99377d9ebfbd13ae8"
 dependencies = [
  "libc",
-]
-
-[[package]]
-name = "itertools"
-version = "0.10.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "37d572918e350e82412fe766d24b15e6682fb2ed2bbe018280caa810397cb319"
-dependencies = [
- "either",
 ]
 
 [[package]]

--- a/cargo-n64/Cargo.toml
+++ b/cargo-n64/Cargo.toml
@@ -11,14 +11,12 @@ keywords = ["cli", "cross", "compilation", "nintendo", "n64"]
 edition = "2018"
 
 [dependencies]
-byteorder = "1.3"
 colored = "2.0"
 crc32fast = "1.2"
 error-iter = "0.2"
 fatfs = "0.3"
 goblin = { version = "0.3", default-features = false, features = ["std", "elf32", "elf64", "endian_fd"] }
 gumdrop = "0.8"
-itertools = "0.10"
 serde = { version = "1.0", features = ["derive"] }
 serde_json = "1.0"
 thiserror = "1.0"

--- a/cargo-n64/src/header.rs
+++ b/cargo-n64/src/header.rs
@@ -1,5 +1,3 @@
-use byteorder::{BigEndian, WriteBytesExt};
-
 use crate::ipl3::IPL3;
 
 pub(crate) const HEADER_SIZE: usize = 0x40;
@@ -83,13 +81,13 @@ impl N64Header {
         buffer.push(self.device_rw_pulse_width);
         buffer.push(self.device_page_size);
         buffer.push(self.device_rw_release_duration);
-        buffer.write_u32::<BigEndian>(self.clock_rate).unwrap();
-        buffer.write_u32::<BigEndian>(self.entry_point).unwrap();
-        buffer.write_u32::<BigEndian>(self.release).unwrap();
+        buffer.extend_from_slice(&self.clock_rate.to_be_bytes());
+        buffer.extend_from_slice(&self.entry_point.to_be_bytes());
+        buffer.extend_from_slice(&self.release.to_be_bytes());
 
         // 0x10
-        buffer.write_u32::<BigEndian>(self.crc1).unwrap();
-        buffer.write_u32::<BigEndian>(self.crc2).unwrap();
+        buffer.extend_from_slice(&self.crc1.to_be_bytes());
+        buffer.extend_from_slice(&self.crc2.to_be_bytes());
         buffer.extend_from_slice(&self._reserved_1);
 
         // 0x20


### PR DESCRIPTION
Minor improvement with fewer dependencies.
- `u32::from_be_bytes` has been stable since 1.39